### PR TITLE
Fixed an issue with array_walk callback

### DIFF
--- a/lib/extras/htmlfilter.php
+++ b/lib/extras/htmlfilter.php
@@ -604,9 +604,9 @@ function tln_sanitize($body,
 	 * Normalize rm_tags and rm_tags_with_content.
 	 */
 	$rm_tags = array_shift($tag_list);
-	@array_walk($tag_list, 'tln_casenormalize');
-	@array_walk($rm_tags_with_content, 'tln_casenormalize');
-	@array_walk($self_closing_tags, 'tln_casenormalize');
+	@array_walk($tag_list, [$this, 'tln_casenormalize']);
+	@array_walk($rm_tags_with_content, [$this, 'tln_casenormalize']);
+	@array_walk($self_closing_tags, [$this, 'tln_casenormalize']);
 	/**
 	 * See if tag_list is of tags to remove or tags to allow.
 	 * false  means remove these tags


### PR DESCRIPTION
#### Details
- Modified the code to use `[$this, 'tln_casenormalize']` instead of a global function call
- Ensures the case normalization method is correctly called within the class context
- Prevents undefined function errors during email parsing

#### Code Change
```php
// Before
@array_walk($tag_list, 'tln_casenormalize');

@array_walk($rm_tags_with_content, 'tln_casenormalize');

@array_walk($self_closing_tags, 'tln_casenormalize');

// After
@array_walk($tag_list, [$this, 'tln_casenormalize']);

@array_walk($rm_tags_with_content, [$this, 'tln_casenormalize']);

@array_walk($self_closing_tags, [$this, 'tln_casenormalize']);